### PR TITLE
Rename Aiven for Redis to Aiven for Caching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Contributions are very welcome on the Aiven netlify-nextjs example. When contrib
 
 # Development
 
-Development of this project requires a PostgreSQL database as well as a Redis database. You can use a local database or use the Aiven for PostgreSQL® and Aiven for Redis® managed databases, available on https://aiven.io.
+Development of this project requires a PostgreSQL database as well as a Redis compatible database. You can use a local database or use the Aiven for PostgreSQL® and Aiven for Caching managed databases, available on https://aiven.io.
 
 ## Local Environment
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nextjs-netlify-mysql-redis
+# nextjs-netlify-mysql
 
 Free [Netlify](https://www.netlify.com/) quickstart recipe libary app using [Next.js](https://nextjs.org/), [Prisma](https://www.prisma.io/) and [Aiven](https://aiven.io). Recipe data is from [kaggle](https://www.kaggle.com/datasets/thedevastator/better-recipes-for-a-better-life).
 
@@ -6,21 +6,21 @@ Free [Netlify](https://www.netlify.com/) quickstart recipe libary app using [Nex
 
 The application is a recipe library where you can browse and inspect recipes. Additionally, you can like recipes that seem interesting and filter list to show only liked ones. Furthermore, you can see interesting statistics from all of the recipes and those that are liked.
 
-MySQL is used as the data storage for storing all recipes and whether they are liked or not. Redis is optional, but when configured statistics are cached to offer faster response time. The database response times are shown in the app to demonstrate the difference. You can get a free MySQL and Redis to use from Aiven by [signing up](https://console.aiven.io/signup?referral_code=v3tvatqoyzbu3yp2oiy9).
+MySQL is used as the data storage for storing all recipes and whether they are liked or not. Aiven for Caching is optional, but when configured statistics are cached to offer faster response time. The database response times are shown in the app to demonstrate the difference.  You can get free services with Aiven for MySQL and Aiven for Caching by [signing up](https://console.aiven.io/signup?referral_code=v3tvatqoyzbu3yp2oiy9).
 
 The application is designed to be hosted on serverless application platform Netlify, which has amazing support for hosting Next.js applications.
 
 # Getting started
 
-The app requires MySQL database. Configuring Redis is optional, but highly recommended to demonstrate all features of the application and the benefits of having a Redis as part of your application. Using `us-east-1` region is recommended to minimise latency, as this region will be closest to where the Netlify functions are deployed if using their free plan.
+The app requires MySQL database. Configuring Aiven for Caching is optional, but highly recommended to demonstrate all features of the application and the benefits of having a Caching as part of your application. Using `us-east-1` region is recommended to minimise latency, as this region will be closest to where the Netlify functions are deployed if using their free plan.
 
-Get free MySQL and Redis from [Aiven](https://console.aiven.io).
+Get free Aiven for MySQL and Aiven for Caching from [Aiven](https://console.aiven.io).
 
 ## Fork and deploy to Netlify
 
 You can fork this branch and deploy the application immediately to Netlify by clicking the button below. Database migrations and seed is done during the Netlify deployment process. Make sure you have MySQL database up and running when deploying to achieve working environment on the first try.
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/dewan-ahmed/nextjs-netlify-mysql-redis)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/Aiven-Labs/nextjs-netlify-mysql)
 
 ## Development setup
 
@@ -55,7 +55,7 @@ You can fork this branch and deploy the application immediately to Netlify by cl
    Choose to create a new site, and then select the default options other prompts. You will be required to authorize Netlify with GitHub.
 
 1. Open site admin UI in Netlify: `npx netlify open --admin`
-1. Go to site configuration section and add environment variables for MySQL and Redis. Check [.env.template](.env.template) for the keys.
+1. Go to site configuration section and add environment variables for MySQL and Aiven for Caching. Check [.env.template](.env.template) for the keys.
 1. Go to deploys section and trigger the deployment by clicking `Trigger deploy` -button.
 1. Access the app from command line with `npx netlify open --site` or open the site from the Netlify admin UI.
 
@@ -63,10 +63,10 @@ You can now push changes and your changes will be automatically deployed to your
 
 # License
 
-nextjs-netlify-mysql-redis is licensed under the Apache license, version 2.0. Full license text is available in the [LICENSE](LICENSE) file.
+nextjs-netlify-mysql is licensed under the Apache license, version 2.0. Full license text is available in the [LICENSE](LICENSE) file.
 
 Please note that the project explicitly does not require a CLA (Contributor License Agreement) from its contributors.
 
 # Contact
 
-Bug reports and patches are very welcome, please post them as GitHub issues and pull requests at https://github.com/dewan-ahmed/nextjs-netlify-mysql-redis.
+Bug reports and patches are very welcome, please post them as GitHub issues and pull requests at https://github.com/Aiven-Labs/nextjs-netlify-mysql.

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -13,7 +13,7 @@ export const Layout: React.FC<{ children: ReactNode }> = ({ children }) => {
     <>
       <Head>
         <title>Recipe library powered by Aiven and Netlify</title>
-        <meta name="description" content="Recipe library built with Next.js, PostgreSQL, Redis and Netlify" />
+        <meta name="description" content="Recipe library built with Next.js, PostgreSQL, Aiven for Caching and Netlify" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/src/lib/ioredis.ts
+++ b/src/lib/ioredis.ts
@@ -16,7 +16,7 @@ const createRedisInstance = () => {
   redis.on('error', () => {
     // eslint-disable-next-line no-console
     console.warn(
-      'Creating Redis instance failed. Results will not cached. Make sure your REDIS_URI environment variable points to a running Aiven for Redis® instance and restart your application.',
+      'Creating Redis instance failed. Results will not cached. Make sure your REDIS_URI environment variable points to a running Aiven for Caching instance and restart your application.',
     );
   });
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,13 +15,13 @@ export default function Home() {
     >
       <Box display="flex" gap="3" justifyContent="center" className="flex-wrap">
         <Chip text="Aiven for PostgreSQL®" />
-        <Chip text="Aiven for Redis®" />
+        <Chip text="Aiven for Caching" />
       </Box>
       <Typography.LargeHeading>
         Free Netlify quickstart recipe library app using Next.js, Prisma and Aiven
       </Typography.LargeHeading>
       <Typography.Large color="grey-60">
-        A PostgreSQL and Redis optimized Next.js application built with Aiven, Prisma and open source data - for free.
+        A PostgreSQL and Aiven for Caching optimized Next.js application built with Aiven, Prisma and open source data - for free.
       </Typography.Large>
       <Box.Flex gap="5" justifyContent="center" className="flex-wrap">
         <Button.ExternalLink

--- a/src/pages/recipes/index.tsx
+++ b/src/pages/recipes/index.tsx
@@ -59,11 +59,11 @@ export default function Recipes() {
               {recipeStatsData?.isRedisAvailable && (
                 <Box minWidth="fit">
                   <Switch
-                    caption="Get statistics faster with Redis"
+                    caption="Get statistics faster with Aiven for Caching"
                     onChange={() => setUseRedis(!useRedis)}
                     checked={useRedis}
                   >
-                    Enable Aiven for Redis®
+                    Enable Aiven for Caching
                   </Switch>
                 </Box>
               )}
@@ -120,16 +120,16 @@ const getStatisticsInfo = (stats: RecipeStatsResponse | undefined, useRedis: boo
   const endToEndRetrievalTime = `${stats?.endToEndRetrievalTimeMs ?? '??'}ms. ${endToEndInfo}`;
 
   if (!stats?.isRedisAvailable) {
-    return `Recipe statistics retrieved from PostgreSQL database in ${endToEndRetrievalTime}. To get cached results using Aiven for Redis®, please follow the instructions to set up your Redis instance.`;
+    return `Recipe statistics retrieved from PostgreSQL database in ${endToEndRetrievalTime}. To get cached results using Aiven for Caching, please follow the instructions to set up your Aiven for Caching instance.`;
   }
 
   if (useRedis) {
     if (stats.fromCache) {
-      return `Recipe statistics cached in Aiven for Redis®, retrieved in ${endToEndRetrievalTime}.`;
+      return `Recipe statistics cached in Aiven for Caching, retrieved in ${endToEndRetrievalTime}.`;
     }
 
-    return `Recipe statistics retrieved from PostgreSQL database in ${endToEndRetrievalTime}. Results are now cached to Aiven for Redis®.`;
+    return `Recipe statistics retrieved from PostgreSQL database in ${endToEndRetrievalTime}. Results are now cached to Aiven for Caching.`;
   }
 
-  return `Recipe statistics retrieved from PostgreSQL database in ${endToEndRetrievalTime}. To get cached results using Aiven for Redis®, please enable it.`;
+  return `Recipe statistics retrieved from PostgreSQL database in ${endToEndRetrievalTime}. To get cached results using Aiven for Caching, please enable it.`;
 };

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,10 +1,10 @@
-# Robust and Secure: Deploy Scalable JAM Stack Applications on Netlify with MySQL and Redis
+# Robust and Secure: Deploy Scalable JAM Stack Applications on Netlify with MySQL and Aiven for Caching
 
-This tutorial guides you through deploying a [Netlify](https://www.netlify.com/) web application with an [Aiven for PostgreSQL](https://aiven.io/mysql) and [Aiven for Redis®](https://aiven.io/redis) backend.
+This tutorial guides you through deploying a [Netlify](https://www.netlify.com/) web application with an [Aiven for MySQL](https://aiven.io/mysql) and [Aiven for Caching](https://aiven.io/caching) backend.
 
-The sample application used in this tutorial is a cooking recipe library displaying open source [recipe data](https://www.kaggle.com/datasets/thedevastator/better-recipes-for-a-better-life). It's built in [Next.js](https://nextjs.org/), which can be deployed to Netlify with ease, and connects to PostgreSQL with [Prisma](https://www.prisma.io/) and Redis with [ioredis](https://www.npmjs.com/package/ioredis).
+The sample application used in this tutorial is a cooking recipe library displaying open source [recipe data](https://www.kaggle.com/datasets/thedevastator/better-recipes-for-a-better-life). It's built in [Next.js](https://nextjs.org/), which can be deployed to Netlify with ease, and connects to PostgreSQL with [Prisma](https://www.prisma.io/) and Aiven for Caching with [ioredis](https://www.npmjs.com/package/ioredis).
 
-The source code for the application is available on GitHub at https://github.com/dewan-ahmed/nextjs-netlify-mysql-redis.
+The source code for the application is available on GitHub at https://github.com/Aiven-Labs/nextjs-netlify-mysql.
 
 # Before you begin
 
@@ -15,14 +15,14 @@ Before starting the tutorial, do the following if you haven't already:
 1. Install the [GitHub CLI](https://github.com/cli/cli#installation).
 1. Install the [Netlify CLI](https://docs.netlify.com/cli/get-started/).
 
-# Step 1. Create free MySQL and Redis services
+# Step 1. Create free MySQL and Aiven for Caching services
 
-Follow the instructions below to create your free MySQL and Redis services with Aiven. You can read more about the Aiven free plans in the [Aiven documentation](https://docs.aiven.io/docs/platform/concepts/free-plan).
+Follow the instructions below to create your free MySQL and Aiven for Caching services with Aiven. You can read more about the Aiven free plans in the [Aiven documentation](https://docs.aiven.io/docs/platform/concepts/free-plan).
 
 1. Login to [Aiven Console](https://console.aiven.io).
 1. In the project you want to create a service in, go to **Services**.
 1. On the **Services** page, click **Create service**.
-1. Select the service you want to create, either **MySQL** or **Redis**.
+1. Select the service you want to create, either **MySQL** or **Aiven for Caching**.
 1. Select **DigitalOcean** as the cloud provider and choose the region.
 
    We recommend using `do-nyc` to minimise latency, as this region will be closest to where the Netlify functions are deployed if using their free plan. However, the Aiven free plans are currently available in the following regions and you can pick whichever you like:
@@ -36,12 +36,12 @@ Follow the instructions below to create your free MySQL and Redis services with 
 
 # Step 2. Get the application code
 
-To deploy the application to Netlify you'll need to have your own GitHub repository for [dewan-ahmed/nextjs-netlify-mysql-redis](https://github.com/dewan-ahmed/nextjs-netlify-mysql-redis). See the relevant [GitHub CLI instructions to fork the repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo?tool=cli#forking-a-repository).
+To deploy the application to Netlify you'll need to have your own GitHub repository for [Aiven-Labs/nextjs-netlify-mysql](https://github.com/Aiven-Labs/nextjs-netlify-mysql). See the relevant [GitHub CLI instructions to fork the repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo?tool=cli#forking-a-repository).
 
 Fork and clone the forked repository with GitHub CLI
 
 ```
-gh repo fork https://github.com/dewan-ahmed/nextjs-netlify-mysql-redis.git --clone --remote
+gh repo fork https://github.com/Aiven-Labs/nextjs-netlify-mysql.git --clone --remote
 ```
 
 You can name the repository by adding `--fork-name <name>` to the command.
@@ -50,10 +50,10 @@ You can name the repository by adding `--fork-name <name>` to the command.
 
 Follow the instructions below to configure continuous deployment. This will automatically deploy your changes.
 
-1. Navigate to the `nextjs-netlify-mysql-redis` directory on your local machine:
+1. Navigate to the `nextjs-netlify-mysql` directory on your local machine:
 
    ```
-   cd nextjs-netlify-mysql-redis
+   cd nextjs-netlify-mysql
    ```
 
 1. Sign into your Netlify account to obtain the access token:
@@ -123,11 +123,11 @@ Congratulations, you have now successfully deployed your application. Any subseq
 
 This example application has a **Home** page with some relevant links and a **Recipes** page where you can browse and inspect recipes. You can like recipes that seem interesting and filter the list to show only liked ones. Furthermore, you can see interesting statistics from all of the recipes and those that are liked.
 
-Aiven for PostgreSQL is used as the database for storing all recipes and whether they are liked or not. Aiven for Redis is optional for the app to function, but when configured statistics are cached to offer faster response time. You are able to toggle Redis on and off. The database response times are shown in the app to demonstrate the difference.
+Aiven for PostgreSQL is used as the database for storing all recipes and whether they are liked or not. Aiven for Caching is optional for the app to function, but when configured statistics are cached to offer faster response time. You are able to toggle Caching on and off. The database response times are shown in the app to demonstrate the difference.
 
 # For more information, see
 
 - [Aiven documentation](https://docs.aiven.io)
-- [Aiven for PostgreSQL documentation](https://docs.aiven.io/docs/products/postgresql)
-- [Aiven for Redis documentation](https://docs.aiven.io/docs/products/redis)
+- [Aiven for MySQL documentation](https://aiven.io/docs/products/mysql)
+- [Aiven for Caching documentation](https://aiven.io/docs/products/caching)
 - [Netlify CLI Command list](https://cli.netlify.com/)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
Previously known as Aiven for Redis®*. As a result of license change and revised trademark guidance from Redis, Aiven has changed the name of Aiven for Redis® to Aiven for Caching. Aiven for Caching offers all the same functionality as Aiven for Redis®.

